### PR TITLE
feat(memory): add LLM-based query rewriting for memory search

### DIFF
--- a/src/semantic-router/pkg/config/config.go
+++ b/src/semantic-router/pkg/config/config.go
@@ -51,6 +51,8 @@ type RouterConfig struct {
 
 	// Semantic cache configuration
 	SemanticCache `yaml:"semantic_cache"`
+	// Memory configuration for agentic memory (cross-session context)
+	Memory MemoryConfig `yaml:"memory"`
 	// Response API configuration for stateful conversations
 	ResponseAPI ResponseAPIConfig `yaml:"response_api"`
 	// LLMObservability for LLM tracing, metrics, and logging
@@ -269,6 +271,36 @@ type SemanticCache struct {
 	// - "gemma": Balanced, 768-dim, supports 8K context
 	// Default: "bert"
 	EmbeddingModel string `yaml:"embedding_model,omitempty"`
+}
+
+// MemoryConfig represents the configuration for agentic memory
+type MemoryConfig struct {
+	// Enable memory features
+	Enabled bool `yaml:"enabled"`
+
+	// Query rewriting configuration
+	QueryRewrite QueryRewriteConfig `yaml:"query_rewrite"`
+}
+
+// QueryRewriteConfig holds configuration for LLM-based query rewriting
+type QueryRewriteConfig struct {
+	// Enable query rewriting
+	Enabled bool `yaml:"enabled"`
+
+	// LLM endpoint for query rewriting (e.g., "http://localhost:8080")
+	Endpoint string `yaml:"endpoint"`
+
+	// Model to use for query rewriting (e.g., "qwen3-7b")
+	Model string `yaml:"model"`
+
+	// Maximum tokens for rewritten query (default: 50)
+	MaxTokens int `yaml:"max_tokens,omitempty"`
+
+	// Temperature for LLM generation (default: 0.1)
+	Temperature float64 `yaml:"temperature,omitempty"`
+
+	// Timeout in seconds for LLM request (default: 5)
+	TimeoutSeconds int `yaml:"timeout_seconds,omitempty"`
 }
 
 // ResponseAPIConfig configures the Response API for stateful conversations.

--- a/src/semantic-router/pkg/extproc/req_filter_memory.go
+++ b/src/semantic-router/pkg/extproc/req_filter_memory.go
@@ -1,11 +1,22 @@
 package extproc
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
 	"regexp"
 	"strings"
+	"time"
 
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 )
+
+// =============================================================================
+// Memory Decision Filter
+// =============================================================================
 
 // Memory Decision Filter
 //
@@ -113,4 +124,257 @@ func IsGreeting(query string) bool {
 	}
 
 	return false
+}
+
+// =============================================================================
+// Query Rewriting for Memory Search
+// =============================================================================
+
+// Query Rewriting for Memory Search
+//
+// This module rewrites vague/context-dependent queries using an LLM to produce
+// self-contained queries suitable for semantic search in a memory database.
+//
+// Example:
+//   History: ["Planning vacation to Hawaii"]
+//   Query: "How much?"
+//   Rewritten: "What is the budget for the Hawaii vacation?"
+
+// ConversationMessage represents a message in conversation history
+type ConversationMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// getTimeout returns the timeout duration from config
+func getTimeout(cfg *config.QueryRewriteConfig) time.Duration {
+	if cfg.TimeoutSeconds > 0 {
+		return time.Duration(cfg.TimeoutSeconds) * time.Second
+	}
+	return 5 * time.Second // default
+}
+
+// getMaxTokens returns max tokens with default
+func getMaxTokens(cfg *config.QueryRewriteConfig) int {
+	if cfg.MaxTokens > 0 {
+		return cfg.MaxTokens
+	}
+	return 50 // default
+}
+
+// getTemperature returns temperature with default
+func getTemperature(cfg *config.QueryRewriteConfig) float64 {
+	if cfg.Temperature > 0 {
+		return cfg.Temperature
+	}
+	return 0.1 // default
+}
+
+// queryRewriteSystemPrompt is the system prompt for query rewriting
+const queryRewriteSystemPrompt = `You are a query rewriter for semantic search in a memory database.
+
+Given conversation history and a user query, rewrite the query to be self-contained 
+for searching memories. Include relevant context from history if the query references 
+previous conversation.
+
+Rules:
+- Keep the rewritten query concise (under 50 words)
+- Preserve the user's intent exactly
+- Include specific entities/topics from history if referenced (e.g., "it", "that", "the second one")
+- If the query is already self-contained, return it unchanged
+- Return ONLY the rewritten query, no explanation or quotes`
+
+// BuildSearchQuery rewrites a query with conversation context for semantic search.
+// It uses an LLM to understand context and produce a self-contained query.
+//
+// Example:
+//
+//	History: ["Planning vacation to Hawaii"]
+//	Query: "How much?"
+//	Result: "What is the budget for the Hawaii vacation?"
+func BuildSearchQuery(ctx context.Context, history []ConversationMessage, query string, cfg *config.QueryRewriteConfig) (string, error) {
+	if cfg == nil || !cfg.Enabled || cfg.Endpoint == "" {
+		logging.Debugf("Memory: Query rewriting disabled, using original query")
+		return query, nil
+	}
+
+	// Format history for the prompt
+	historyText := formatHistoryForPrompt(history)
+
+	// Build user prompt
+	userPrompt := fmt.Sprintf("History:\n%s\n\nQuery: %s\n\nRewritten query:", historyText, query)
+
+	// TODO: Remove debug logs after POC demo
+	logging.Infof("╔══════════════════════════════════════════════════════════════════╗")
+	logging.Infof("║                    MEMORY QUERY REWRITING                        ║")
+	logging.Infof("╠══════════════════════════════════════════════════════════════════╣")
+	logging.Infof("║ HISTORY:                                                         ║")
+	for _, msg := range history {
+		logging.Infof("║   [%s]: %s", msg.Role, truncateForLog(msg.Content, 50))
+	}
+	logging.Infof("╠══════════════════════════════════════════════════════════════════╣")
+	logging.Infof("║ ORIGINAL QUERY: %s", query)
+	logging.Infof("╚══════════════════════════════════════════════════════════════════╝")
+
+	// Call LLM for rewriting
+	rewrittenQuery, err := callLLMForQueryRewrite(ctx, cfg, userPrompt)
+	if err != nil {
+		logging.Errorf("Memory: Query rewriting failed, using original: %v", err)
+		// Fallback to original query on error
+		return query, nil
+	}
+
+	// Clean up the response
+	rewrittenQuery = strings.TrimSpace(rewrittenQuery)
+	rewrittenQuery = strings.Trim(rewrittenQuery, "\"'")
+
+	// TODO: Remove debug logs after POC demo
+	logging.Infof("╔══════════════════════════════════════════════════════════════════╗")
+	logging.Infof("║ REWRITTEN QUERY: %s", rewrittenQuery)
+	logging.Infof("╚══════════════════════════════════════════════════════════════════╝")
+
+	return rewrittenQuery, nil
+}
+
+// formatHistoryForPrompt formats conversation history for the LLM prompt
+func formatHistoryForPrompt(history []ConversationMessage) string {
+	if len(history) == 0 {
+		return "(no previous conversation)"
+	}
+
+	var lines []string
+	// Only use last 5 messages to keep context manageable
+	startIdx := 0
+	if len(history) > 5 {
+		startIdx = len(history) - 5
+	}
+
+	for _, msg := range history[startIdx:] {
+		lines = append(lines, fmt.Sprintf("[%s]: %s", msg.Role, msg.Content))
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// truncateForLog truncates a string for logging purposes
+func truncateForLog(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}
+
+// =============================================================================
+// LLM Client for Query Rewriting
+// =============================================================================
+
+// llmChatRequest represents an OpenAI-compatible chat request
+type llmChatRequest struct {
+	Model       string           `json:"model"`
+	Messages    []llmChatMessage `json:"messages"`
+	MaxTokens   int              `json:"max_tokens,omitempty"`
+	Temperature float64          `json:"temperature,omitempty"`
+	Stream      bool             `json:"stream"`
+}
+
+type llmChatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// llmChatResponse represents an OpenAI-compatible chat response
+type llmChatResponse struct {
+	Choices []struct {
+		Message struct {
+			Content string `json:"content"`
+		} `json:"message"`
+	} `json:"choices"`
+}
+
+// callLLMForQueryRewrite calls the LLM endpoint for query rewriting
+func callLLMForQueryRewrite(ctx context.Context, cfg *config.QueryRewriteConfig, userPrompt string) (string, error) {
+	// Build request
+	reqBody := llmChatRequest{
+		Model: cfg.Model,
+		Messages: []llmChatMessage{
+			{Role: "system", Content: queryRewriteSystemPrompt},
+			{Role: "user", Content: userPrompt},
+		},
+		MaxTokens:   getMaxTokens(cfg),
+		Temperature: getTemperature(cfg),
+		Stream:      false,
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	// Create HTTP request
+	url := fmt.Sprintf("%s/v1/chat/completions", strings.TrimSuffix(cfg.Endpoint, "/"))
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(jsonData))
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	// Send request
+	client := &http.Client{Timeout: getTimeout(cfg)}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return "", fmt.Errorf("LLM request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("LLM returned status %d", resp.StatusCode)
+	}
+
+	// Parse response
+	var llmResp llmChatResponse
+	if err := json.NewDecoder(resp.Body).Decode(&llmResp); err != nil {
+		return "", fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	if len(llmResp.Choices) == 0 {
+		return "", fmt.Errorf("no choices in LLM response")
+	}
+
+	return llmResp.Choices[0].Message.Content, nil
+}
+
+// =============================================================================
+// Helper: Extract History from OpenAI Messages
+// =============================================================================
+
+// ExtractConversationHistory extracts conversation history from raw request messages.
+// It filters out system messages and returns user/assistant messages for context.
+func ExtractConversationHistory(messagesJSON []byte) ([]ConversationMessage, error) {
+	var messages []map[string]interface{}
+	if err := json.Unmarshal(messagesJSON, &messages); err != nil {
+		return nil, fmt.Errorf("failed to parse messages: %w", err)
+	}
+
+	var history []ConversationMessage
+	for _, msg := range messages {
+		role, ok := msg["role"].(string)
+		// Skip if no role or system messages (not conversation history)
+		if !ok || role == "system" {
+			continue
+		}
+
+		// Extract content - skip empty
+		content, ok := msg["content"].(string)
+		if !ok || content == "" {
+			continue
+		}
+
+		history = append(history, ConversationMessage{
+			Role:    role,
+			Content: content,
+		})
+	}
+
+	return history, nil
 }


### PR DESCRIPTION

Implement context-aware query rewriting that transforms vague, context-
dependent queries into self-contained queries suitable for semantic
search in the memory database.

Changes:
- Add BuildSearchQuery() function that uses LLM to rewrite queries
  with conversation history context (e.g., "How much?" → "What is the
  budget for the Hawaii vacation?")
- Add ExtractConversationHistory() to parse Chat API messages format
- Add formatHistoryForPrompt() with 5-message context window limit
- Add MemoryConfig and QueryRewriteConfig structs to RouterConfig
  for YAML-based configuration of LLM endpoint, model, timeout, etc.
- Add debug logging with pretty-print for POC demo (marked with TODO)
- Add 20 unit tests with mock HTTP server covering:
  * Config validation (disabled, nil, no endpoint)
  * LLM request/response handling
  * Error fallback to original query
  * Response cleanup (quotes, whitespace)
  * History extraction and formatting

Design decisions:
- Always use LLM rewriting rather than heuristics for self-contained
  detection, as the LLM handles edge cases more reliably
- Graceful fallback: LLM errors return original query without failing
- Context limited to last 5 messages to manage token usage

Resolves #3