### PR TITLE
feat(memory): add memory injection into LLM requests

### DIFF
--- a/src/semantic-router/pkg/extproc/req_filter_memory_test.go
+++ b/src/semantic-router/pkg/extproc/req_filter_memory_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/memory"
 )
 
 // =============================================================================
@@ -863,4 +864,339 @@ func TestTruncateForLog(t *testing.T) {
 	assert.Equal(t, "this is a ...", truncateForLog("this is a long string", 10))
 	assert.Equal(t, "", truncateForLog("", 10))
 	assert.Equal(t, "exactly10!", truncateForLog("exactly10!", 10))
+}
+
+// =============================================================================
+// InjectMemories Tests
+// =============================================================================
+
+func TestInjectMemories_NoMemories(t *testing.T) {
+	originalRequest := []byte(`{"model":"test","messages":[{"role":"user","content":"Hello"}]}`)
+
+	result, err := InjectMemories(originalRequest, nil)
+	require.NoError(t, err)
+	assert.Equal(t, originalRequest, result, "should return original when no memories")
+
+	result, err = InjectMemories(originalRequest, []*memory.RetrieveResult{})
+	require.NoError(t, err)
+	assert.Equal(t, originalRequest, result, "should return original when empty memories")
+}
+
+func TestInjectMemories_SingleMemory(t *testing.T) {
+	originalRequest := []byte(`{"model":"test","messages":[{"role":"user","content":"What's my budget?"}]}`)
+
+	memories := []*memory.RetrieveResult{
+		{
+			Memory: &memory.Memory{Content: "Hawaii trip budget is $10,000"},
+			Score:  0.85,
+		},
+	}
+
+	result, err := InjectMemories(originalRequest, memories)
+	require.NoError(t, err)
+
+	// Parse result to verify
+	var parsed map[string]interface{}
+	err = json.Unmarshal(result, &parsed)
+	require.NoError(t, err)
+
+	messages, ok := parsed["messages"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, messages, 2, "should have system + user message")
+
+	// First message should be system with memory context
+	firstMsg := messages[0].(map[string]interface{})
+	assert.Equal(t, "system", firstMsg["role"])
+	assert.Contains(t, firstMsg["content"], "User's Relevant Context")
+	assert.Contains(t, firstMsg["content"], "Hawaii trip budget is $10,000")
+}
+
+func TestInjectMemories_MultipleMemories(t *testing.T) {
+	originalRequest := []byte(`{"model":"test","messages":[{"role":"user","content":"Tell me about my trip"}]}`)
+
+	memories := []*memory.RetrieveResult{
+		{
+			Memory: &memory.Memory{Content: "Hawaii trip budget is $10,000"},
+			Score:  0.85,
+		},
+		{
+			Memory: &memory.Memory{Content: "User prefers direct flights"},
+			Score:  0.72,
+		},
+		{
+			Memory: &memory.Memory{Content: "Trip planned for December 2025"},
+			Score:  0.68,
+		},
+	}
+
+	result, err := InjectMemories(originalRequest, memories)
+	require.NoError(t, err)
+
+	// Parse result to verify
+	var parsed map[string]interface{}
+	err = json.Unmarshal(result, &parsed)
+	require.NoError(t, err)
+
+	messages := parsed["messages"].([]interface{})
+	firstMsg := messages[0].(map[string]interface{})
+	content := firstMsg["content"].(string)
+
+	assert.Contains(t, content, "Hawaii trip budget is $10,000")
+	assert.Contains(t, content, "User prefers direct flights")
+	assert.Contains(t, content, "Trip planned for December 2025")
+}
+
+func TestInjectMemories_ExistingSystemMessage(t *testing.T) {
+	// Request already has a system message
+	originalRequest := []byte(`{
+		"model":"test",
+		"messages":[
+			{"role":"system","content":"You are a helpful assistant."},
+			{"role":"user","content":"What's my budget?"}
+		]
+	}`)
+
+	memories := []*memory.RetrieveResult{
+		{
+			Memory: &memory.Memory{Content: "Hawaii trip budget is $10,000"},
+			Score:  0.85,
+		},
+	}
+
+	result, err := InjectMemories(originalRequest, memories)
+	require.NoError(t, err)
+
+	// Parse result
+	var parsed map[string]interface{}
+	err = json.Unmarshal(result, &parsed)
+	require.NoError(t, err)
+
+	messages := parsed["messages"].([]interface{})
+	require.Len(t, messages, 2, "should still have 2 messages (context appended)")
+
+	// System message should have both original content and memory
+	systemMsg := messages[0].(map[string]interface{})
+	content := systemMsg["content"].(string)
+	assert.Contains(t, content, "You are a helpful assistant.")
+	assert.Contains(t, content, "User's Relevant Context")
+	assert.Contains(t, content, "Hawaii trip budget is $10,000")
+}
+
+func TestInjectMemories_InvalidJSON(t *testing.T) {
+	invalidRequest := []byte(`not valid json`)
+
+	memories := []*memory.RetrieveResult{
+		{Memory: &memory.Memory{Content: "test memory"}, Score: 0.8},
+	}
+
+	// Should return original on error (graceful fallback)
+	result, err := InjectMemories(invalidRequest, memories)
+	require.NoError(t, err, "should not return error, just fallback")
+	assert.Equal(t, invalidRequest, result, "should return original on parse error")
+}
+
+func TestInjectMemories_EmptyMessages(t *testing.T) {
+	// Request with empty messages array
+	originalRequest := []byte(`{"model":"test","messages":[]}`)
+
+	memories := []*memory.RetrieveResult{
+		{Memory: &memory.Memory{Content: "test memory"}, Score: 0.8},
+	}
+
+	result, err := InjectMemories(originalRequest, memories)
+	require.NoError(t, err)
+
+	var parsed map[string]interface{}
+	err = json.Unmarshal(result, &parsed)
+	require.NoError(t, err)
+
+	messages := parsed["messages"].([]interface{})
+	require.Len(t, messages, 1, "should have system message added")
+
+	systemMsg := messages[0].(map[string]interface{})
+	assert.Equal(t, "system", systemMsg["role"])
+	assert.Contains(t, systemMsg["content"], "test memory")
+}
+
+func TestInjectMemories_NilMemoryContent(t *testing.T) {
+	originalRequest := []byte(`{"model":"test","messages":[{"role":"user","content":"test"}]}`)
+
+	memories := []*memory.RetrieveResult{
+		{Memory: nil, Score: 0.8},                         // nil memory
+		{Memory: &memory.Memory{Content: ""}, Score: 0.7}, // empty content
+		{Memory: &memory.Memory{Content: "valid memory"}, Score: 0.6},
+	}
+
+	result, err := InjectMemories(originalRequest, memories)
+	require.NoError(t, err)
+
+	var parsed map[string]interface{}
+	err = json.Unmarshal(result, &parsed)
+	require.NoError(t, err)
+
+	messages := parsed["messages"].([]interface{})
+	systemMsg := messages[0].(map[string]interface{})
+	content := systemMsg["content"].(string)
+
+	// Should only contain the valid memory
+	assert.Contains(t, content, "valid memory")
+	assert.NotContains(t, content, "nil") // No nil memory content
+}
+
+// =============================================================================
+// FormatMemoriesAsContext Tests
+// =============================================================================
+
+func TestFormatMemoriesAsContext_Empty(t *testing.T) {
+	result := FormatMemoriesAsContext(nil)
+	assert.Equal(t, "", result)
+
+	result = FormatMemoriesAsContext([]*memory.RetrieveResult{})
+	assert.Equal(t, "", result)
+}
+
+func TestFormatMemoriesAsContext_SingleMemory(t *testing.T) {
+	memories := []*memory.RetrieveResult{
+		{Memory: &memory.Memory{Content: "Budget is $10,000"}, Score: 0.85},
+	}
+
+	result := FormatMemoriesAsContext(memories)
+
+	assert.Contains(t, result, "## User's Relevant Context")
+	assert.Contains(t, result, "- Budget is $10,000")
+}
+
+func TestFormatMemoriesAsContext_MultipleMemories(t *testing.T) {
+	memories := []*memory.RetrieveResult{
+		{Memory: &memory.Memory{Content: "Budget is $10,000"}, Score: 0.85},
+		{Memory: &memory.Memory{Content: "Prefers direct flights"}, Score: 0.72},
+	}
+
+	result := FormatMemoriesAsContext(memories)
+
+	assert.Contains(t, result, "## User's Relevant Context")
+	assert.Contains(t, result, "- Budget is $10,000")
+	assert.Contains(t, result, "- Prefers direct flights")
+}
+
+func TestFormatMemoriesAsContext_SkipsNilAndEmpty(t *testing.T) {
+	memories := []*memory.RetrieveResult{
+		{Memory: nil, Score: 0.9},
+		{Memory: &memory.Memory{Content: ""}, Score: 0.8},
+		{Memory: &memory.Memory{Content: "Valid content"}, Score: 0.7},
+	}
+
+	result := FormatMemoriesAsContext(memories)
+
+	assert.Contains(t, result, "- Valid content")
+	// Should only have one bullet point
+	assert.Equal(t, 1, countOccurrences(result, "- "))
+}
+
+// =============================================================================
+// Integration-like Tests
+// =============================================================================
+
+func TestInjectMemories_RealisticScenario(t *testing.T) {
+	// Simulate a realistic request with system prompt, history, and user query
+	originalRequest := []byte(`{
+		"model": "qwen3-7b",
+		"messages": [
+			{"role": "system", "content": "You are a helpful travel assistant."},
+			{"role": "user", "content": "I want to plan a trip to Hawaii"},
+			{"role": "assistant", "content": "Great choice! Hawaii is beautiful. What's your budget?"},
+			{"role": "user", "content": "How much did I say my budget was?"}
+		],
+		"temperature": 0.7,
+		"max_tokens": 1024
+	}`)
+
+	memories := []*memory.RetrieveResult{
+		{
+			Memory: &memory.Memory{
+				Content: "User's budget for Hawaii trip is $10,000",
+				Type:    memory.MemoryTypeSemantic,
+			},
+			Score: 0.92,
+		},
+		{
+			Memory: &memory.Memory{
+				Content: "User prefers direct flights over connections",
+				Type:    memory.MemoryTypeSemantic,
+			},
+			Score: 0.78,
+		},
+	}
+
+	result, err := InjectMemories(originalRequest, memories)
+	require.NoError(t, err)
+
+	// Parse and validate
+	var parsed map[string]interface{}
+	err = json.Unmarshal(result, &parsed)
+	require.NoError(t, err)
+
+	// Verify model and other fields preserved
+	assert.Equal(t, "qwen3-7b", parsed["model"])
+	assert.Equal(t, float64(0.7), parsed["temperature"])
+	assert.Equal(t, float64(1024), parsed["max_tokens"])
+
+	// Verify messages
+	messages := parsed["messages"].([]interface{})
+	require.Len(t, messages, 4, "should have same number of messages")
+
+	// System message should be enhanced
+	systemMsg := messages[0].(map[string]interface{})
+	content := systemMsg["content"].(string)
+	assert.Contains(t, content, "You are a helpful travel assistant")
+	assert.Contains(t, content, "User's Relevant Context")
+	assert.Contains(t, content, "budget for Hawaii trip is $10,000")
+	assert.Contains(t, content, "prefers direct flights")
+}
+
+func TestInjectMemories_PreservesMessageOrder(t *testing.T) {
+	originalRequest := []byte(`{
+		"model": "test",
+		"messages": [
+			{"role": "user", "content": "First message"},
+			{"role": "assistant", "content": "Response"},
+			{"role": "user", "content": "Second message"}
+		]
+	}`)
+
+	memories := []*memory.RetrieveResult{
+		{Memory: &memory.Memory{Content: "Memory content"}, Score: 0.8},
+	}
+
+	result, err := InjectMemories(originalRequest, memories)
+	require.NoError(t, err)
+
+	var parsed map[string]interface{}
+	err = json.Unmarshal(result, &parsed)
+	require.NoError(t, err)
+
+	messages := parsed["messages"].([]interface{})
+	require.Len(t, messages, 4, "should have system + 3 original messages")
+
+	// Verify order: system, user, assistant, user
+	assert.Equal(t, "system", messages[0].(map[string]interface{})["role"])
+	assert.Equal(t, "user", messages[1].(map[string]interface{})["role"])
+	assert.Equal(t, "assistant", messages[2].(map[string]interface{})["role"])
+	assert.Equal(t, "user", messages[3].(map[string]interface{})["role"])
+
+	// Verify content preserved
+	assert.Equal(t, "First message", messages[1].(map[string]interface{})["content"])
+	assert.Equal(t, "Response", messages[2].(map[string]interface{})["content"])
+	assert.Equal(t, "Second message", messages[3].(map[string]interface{})["content"])
+}
+
+// Helper function
+func countOccurrences(s, substr string) int {
+	count := 0
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			count++
+		}
+	}
+	return count
 }

--- a/src/semantic-router/pkg/memory/types.go
+++ b/src/semantic-router/pkg/memory/types.go
@@ -1,0 +1,99 @@
+package memory
+
+import "time"
+
+// MemoryType represents the category of a memory
+type MemoryType string
+
+const (
+	// MemoryTypeSemantic represents facts, preferences, knowledge
+	// Example: "User's budget for Hawaii is $10,000"
+	MemoryTypeSemantic MemoryType = "semantic"
+
+	// MemoryTypeProcedural represents instructions, how-to, steps
+	// Example: "To deploy payment-service: run npm build, then docker push"
+	MemoryTypeProcedural MemoryType = "procedural"
+
+	// MemoryTypeEpisodic represents session summaries, past events
+	// Example: "On Dec 29 2024, user planned Hawaii vacation with $10K budget"
+	MemoryTypeEpisodic MemoryType = "episodic"
+)
+
+// Memory represents a stored memory unit in the agentic memory system
+type Memory struct {
+	// ID is the unique identifier for this memory
+	ID string `json:"id"`
+
+	// Type is the category of this memory (semantic, procedural, episodic)
+	Type MemoryType `json:"type"`
+
+	// Content is the actual memory text
+	// Should be self-contained with context (e.g., "budget for Hawaii is $10K" not just "$10K")
+	Content string `json:"content"`
+
+	// Embedding is the vector representation (not serialized to JSON)
+	Embedding []float32 `json:"-"`
+
+	// UserID is the owner of this memory (for user isolation)
+	UserID string `json:"user_id"`
+
+	// ProjectID is an optional project scope
+	ProjectID string `json:"project_id,omitempty"`
+
+	// Source indicates where this memory came from
+	Source string `json:"source,omitempty"`
+
+	// CreatedAt is when the memory was first stored
+	CreatedAt time.Time `json:"created_at"`
+
+	// UpdatedAt is when the memory was last modified
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
+
+	// AccessCount tracks how often this memory is retrieved
+	AccessCount int `json:"access_count"`
+
+	// Importance is a score for prioritizing memories (0.0 to 1.0)
+	Importance float32 `json:"importance"`
+}
+
+// RetrieveResult represents a memory retrieved from search with its relevance score
+type RetrieveResult struct {
+	// Memory is the retrieved memory
+	Memory *Memory `json:"memory"`
+
+	// Score is the similarity score (0.0 to 1.0, higher = more relevant)
+	Score float32 `json:"score"`
+}
+
+// RetrieveOptions configures memory retrieval
+type RetrieveOptions struct {
+	// Query is the search query (will be embedded for vector search)
+	Query string
+
+	// UserID filters memories to this user only
+	UserID string
+
+	// ProjectID optionally filters to a specific project
+	ProjectID string
+
+	// Types optionally filters to specific memory types
+	Types []MemoryType
+
+	// Limit is the maximum number of results to return
+	Limit int
+
+	// Threshold is the minimum similarity score (0.0 to 1.0)
+	Threshold float32
+}
+
+// MemoryScope defines the scope for bulk operations (e.g., ForgetByScope)
+type MemoryScope struct {
+	// UserID is required - all operations are user-scoped
+	UserID string
+
+	// ProjectID optionally narrows scope to a project
+	ProjectID string
+
+	// Types optionally narrows scope to specific memory types
+	Types []MemoryType
+}


### PR DESCRIPTION

Implement InjectMemories() to add retrieved memories to LLM requests
as system context, enabling cross-session personalization.

Changes:
- Add pkg/memory/types.go with Memory, RetrieveResult, RetrieveOptions
- Add InjectMemories() to format and inject memories as system message
- Add FormatMemoriesAsContext() to create readable context block
- Add injectSystemMessage() to handle JSON manipulation
- Graceful fallback: returns original request on any error

Design decisions:
- Appends to existing system message if present (preserves prompts)
- Prepends new system message if none exists
- Skips nil/empty memories in formatting
- No external dependencies - works with mock data for testing

Tests:
- 13 unit tests covering all scenarios
- Realistic scenario test with full request structure
- Edge cases: empty, nil, invalid JSON, existing system message

Resolves #5