### PR TITLE
feat(memory): add LLM-based fact extraction for agentic memory

### DIFF
--- a/src/semantic-router/pkg/config/config.go
+++ b/src/semantic-router/pkg/config/config.go
@@ -280,6 +280,9 @@ type MemoryConfig struct {
 
 	// Query rewriting configuration
 	QueryRewrite QueryRewriteConfig `yaml:"query_rewrite"`
+
+	// Fact extraction configuration
+	Extraction ExtractionConfig `yaml:"extraction"`
 }
 
 // QueryRewriteConfig holds configuration for LLM-based query rewriting
@@ -301,6 +304,31 @@ type QueryRewriteConfig struct {
 
 	// Timeout in seconds for LLM request (default: 5)
 	TimeoutSeconds int `yaml:"timeout_seconds,omitempty"`
+}
+
+// ExtractionConfig holds configuration for LLM-based fact extraction from conversations.
+// Facts are extracted from conversation history and stored in long-term memory.
+type ExtractionConfig struct {
+	// Enable fact extraction
+	Enabled bool `yaml:"enabled"`
+
+	// LLM endpoint for fact extraction (e.g., "http://localhost:8080")
+	Endpoint string `yaml:"endpoint"`
+
+	// Model to use for extraction (e.g., "qwen3-7b")
+	Model string `yaml:"model"`
+
+	// Maximum tokens for extracted facts (default: 500)
+	MaxTokens int `yaml:"max_tokens,omitempty"`
+
+	// Temperature for LLM generation (default: 0.1)
+	Temperature float64 `yaml:"temperature,omitempty"`
+
+	// Timeout in seconds for LLM request (default: 30)
+	TimeoutSeconds int `yaml:"timeout_seconds,omitempty"`
+
+	// BatchSize is the number of turns between extraction runs (default: 10)
+	BatchSize int `yaml:"batch_size,omitempty"`
 }
 
 // ResponseAPIConfig configures the Response API for stateful conversations.

--- a/src/semantic-router/pkg/memory/extractor.go
+++ b/src/semantic-router/pkg/memory/extractor.go
@@ -1,0 +1,343 @@
+package memory
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+)
+
+// =============================================================================
+// Memory Extractor
+// =============================================================================
+
+// MemoryExtractor extracts facts from conversation history using an LLM.
+// It analyzes conversation messages and identifies important information
+// to store in long-term memory (facts, preferences, procedural knowledge).
+//
+// Usage:
+//
+//	extractor := NewMemoryExtractor(cfg)
+//	facts, err := extractor.ExtractFacts(ctx, messages)
+type MemoryExtractor struct {
+	config *config.ExtractionConfig
+	client *http.Client // Reused for connection pooling
+}
+
+// NewMemoryExtractor creates a new MemoryExtractor with the given configuration.
+// The http.Client is reused across requests for connection pooling.
+func NewMemoryExtractor(cfg *config.ExtractionConfig) *MemoryExtractor {
+	return &MemoryExtractor{
+		config: cfg,
+		client: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// =============================================================================
+// LLM-Based Fact Extraction
+// =============================================================================
+
+// extractionSystemPrompt is the system prompt for fact extraction
+const extractionSystemPrompt = `You are a memory extraction system. Extract important information from conversations.
+
+RULES:
+1. Extract facts, preferences, decisions, and procedural knowledge
+2. ALWAYS include context - never extract isolated values
+3. Use self-contained phrases that make sense without the conversation
+4. Return ONLY valid JSON - no explanations or markdown
+
+EXAMPLES:
+BAD:  {"type": "semantic", "content": "budget is $10,000"}
+GOOD: {"type": "semantic", "content": "User's budget for Hawaii vacation is $10,000"}
+
+BAD:  {"type": "procedural", "content": "run npm build"}
+GOOD: {"type": "procedural", "content": "To deploy payment-service: run npm build, then docker push"}
+
+TYPES:
+- "semantic": Facts, preferences, knowledge (e.g., "User prefers direct flights")
+- "procedural": Instructions, how-to, steps (e.g., "To reset password: click forgot, enter email")
+
+Return JSON array. Empty array [] if nothing worth remembering.`
+
+// ExtractFacts extracts memorable facts from a conversation using an LLM.
+//
+// Error handling:
+//   - Returns empty slice on any error (graceful degradation)
+//   - Logs warnings for debugging but doesn't fail the response
+//
+// Example:
+//
+//	messages := []Message{
+//	    {Role: "user", Content: "My budget for Hawaii is $10,000"},
+//	    {Role: "assistant", Content: "Great! That's a good budget for Hawaii."},
+//	}
+//	facts, err := extractor.ExtractFacts(ctx, messages)
+//	// facts = [{Type: "semantic", Content: "User's budget for Hawaii vacation is $10,000"}]
+func (e *MemoryExtractor) ExtractFacts(ctx context.Context, messages []Message) ([]ExtractedFact, error) {
+	if e.config == nil || !e.config.Enabled || e.config.Endpoint == "" {
+		logging.Debugf("Memory: Fact extraction disabled or not configured")
+		return nil, nil
+	}
+
+	if len(messages) == 0 {
+		return nil, nil
+	}
+
+	// Format messages for the prompt
+	conversationText := formatMessagesForExtraction(messages)
+
+	// Build user prompt
+	userPrompt := fmt.Sprintf("Extract important information from this conversation:\n\n%s\n\nReturn JSON array:", conversationText)
+
+	// TODO: Remove debug logs after POC demo
+	logging.Infof("╔══════════════════════════════════════════════════════════════════╗")
+	logging.Infof("║                    MEMORY FACT EXTRACTION                        ║")
+	logging.Infof("╠══════════════════════════════════════════════════════════════════╣")
+	logging.Infof("║ MESSAGES TO EXTRACT FROM (%d messages):                          ║", len(messages))
+	for _, msg := range messages {
+		logging.Infof("║   [%s]: %s", msg.Role, truncateForLog(msg.Content, 50))
+	}
+	logging.Infof("╚══════════════════════════════════════════════════════════════════╝")
+
+	// Call LLM for extraction
+	facts, err := e.callLLMForExtraction(ctx, userPrompt)
+	if err != nil {
+		logging.Warnf("Memory: Fact extraction failed: %v", err)
+		return nil, nil // Graceful degradation
+	}
+
+	// TODO: Remove debug logs after POC demo
+	logging.Infof("╔══════════════════════════════════════════════════════════════════╗")
+	logging.Infof("║ EXTRACTED FACTS (%d):                                            ║", len(facts))
+	for i, fact := range facts {
+		logging.Infof("║   %d. [%s] %s", i+1, fact.Type, truncateForLog(fact.Content, 45))
+	}
+	logging.Infof("╚══════════════════════════════════════════════════════════════════╝")
+
+	return facts, nil
+}
+
+// callLLMForExtraction calls the configured LLM endpoint for fact extraction
+func (e *MemoryExtractor) callLLMForExtraction(ctx context.Context, userPrompt string) ([]ExtractedFact, error) {
+	// Build request
+	reqBody := llmChatRequest{
+		Model: e.config.Model,
+		Messages: []llmChatMessage{
+			{Role: "system", Content: extractionSystemPrompt},
+			{Role: "user", Content: userPrompt},
+		},
+		MaxTokens:   getMaxTokensForExtraction(e.config),
+		Temperature: getTemperatureForExtraction(e.config),
+		Stream:      false,
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	// Create HTTP request with timeout
+	timeout := getTimeoutForExtraction(e.config)
+	reqCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	url := fmt.Sprintf("%s/v1/chat/completions", strings.TrimSuffix(e.config.Endpoint, "/"))
+	httpReq, err := http.NewRequestWithContext(reqCtx, "POST", url, bytes.NewReader(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	// Send request (using reused client for connection pooling)
+	resp, err := e.client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("LLM request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("LLM returned status %d", resp.StatusCode)
+	}
+
+	// Parse response
+	var llmResp llmChatResponse
+	if err := json.NewDecoder(resp.Body).Decode(&llmResp); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	if len(llmResp.Choices) == 0 {
+		return nil, fmt.Errorf("no choices in LLM response")
+	}
+
+	// Parse extracted facts from LLM response
+	content := llmResp.Choices[0].Message.Content
+	return parseExtractedFacts(content)
+}
+
+// =============================================================================
+// Response Parsing
+// =============================================================================
+
+// parseExtractedFacts parses the LLM response into ExtractedFact structs
+func parseExtractedFacts(content string) ([]ExtractedFact, error) {
+	// Clean up the response - remove markdown code blocks if present
+	content = strings.TrimSpace(content)
+	content = cleanJSONResponse(content)
+
+	if content == "" || content == "[]" {
+		return nil, nil
+	}
+
+	// Parse JSON array
+	var facts []ExtractedFact
+	if err := json.Unmarshal([]byte(content), &facts); err != nil {
+		return nil, fmt.Errorf("failed to parse facts JSON: %w (content: %s)", err, truncateForLog(content, 100))
+	}
+
+	// Validate and filter facts
+	validFacts := make([]ExtractedFact, 0, len(facts))
+	for _, fact := range facts {
+		// Skip empty content
+		if strings.TrimSpace(fact.Content) == "" {
+			continue
+		}
+
+		// Normalize type
+		normalizedType := normalizeMemoryType(string(fact.Type))
+		if normalizedType == "" {
+			logging.Warnf("Memory: Skipping fact with invalid type: %s", fact.Type)
+			continue
+		}
+
+		validFacts = append(validFacts, ExtractedFact{
+			Type:    normalizedType,
+			Content: strings.TrimSpace(fact.Content),
+		})
+	}
+
+	return validFacts, nil
+}
+
+// cleanJSONResponse removes markdown code blocks and other formatting from LLM response
+func cleanJSONResponse(content string) string {
+	// Remove markdown code blocks
+	// Match ```json ... ``` or ``` ... ```
+	codeBlockPattern := regexp.MustCompile("(?s)```(?:json)?\\s*(.+?)\\s*```")
+	if matches := codeBlockPattern.FindStringSubmatch(content); len(matches) > 1 {
+		content = matches[1]
+	}
+
+	// Trim whitespace
+	content = strings.TrimSpace(content)
+
+	return content
+}
+
+// normalizeMemoryType converts string to MemoryType, returns empty string if invalid
+func normalizeMemoryType(typeStr string) MemoryType {
+	switch strings.ToLower(strings.TrimSpace(typeStr)) {
+	case "semantic":
+		return MemoryTypeSemantic
+	case "procedural":
+		return MemoryTypeProcedural
+	case "episodic":
+		return MemoryTypeEpisodic
+	default:
+		return ""
+	}
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+// formatMessagesForExtraction formats messages for the LLM extraction prompt
+func formatMessagesForExtraction(messages []Message) string {
+	var lines []string
+	for _, msg := range messages {
+		lines = append(lines, fmt.Sprintf("[%s]: %s", msg.Role, msg.Content))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// truncateForLog truncates a string for logging purposes
+func truncateForLog(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}
+
+// getTimeoutForExtraction returns timeout with default (30s for extraction)
+func getTimeoutForExtraction(cfg *config.ExtractionConfig) time.Duration {
+	if cfg.TimeoutSeconds > 0 {
+		return time.Duration(cfg.TimeoutSeconds) * time.Second
+	}
+	return 30 * time.Second // default for extraction (longer than query rewrite)
+}
+
+// getMaxTokensForExtraction returns max tokens with default
+func getMaxTokensForExtraction(cfg *config.ExtractionConfig) int {
+	if cfg.MaxTokens > 0 {
+		return cfg.MaxTokens
+	}
+	return 500 // default - extraction can produce multiple facts
+}
+
+// getTemperatureForExtraction returns temperature with default
+func getTemperatureForExtraction(cfg *config.ExtractionConfig) float64 {
+	if cfg.Temperature > 0 {
+		return cfg.Temperature
+	}
+	return 0.1 // default - low temperature for consistent extraction
+}
+
+// =============================================================================
+// LLM Client Types (shared with req_filter_memory.go)
+// =============================================================================
+
+// llmChatRequest represents an OpenAI-compatible chat request
+type llmChatRequest struct {
+	Model       string           `json:"model"`
+	Messages    []llmChatMessage `json:"messages"`
+	MaxTokens   int              `json:"max_tokens,omitempty"`
+	Temperature float64          `json:"temperature,omitempty"`
+	Stream      bool             `json:"stream"`
+}
+
+type llmChatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// llmChatResponse represents an OpenAI-compatible chat response
+type llmChatResponse struct {
+	Choices []struct {
+		Message struct {
+			Content string `json:"content"`
+		} `json:"message"`
+	} `json:"choices"`
+}
+
+// =============================================================================
+// Utility Functions
+// =============================================================================
+
+// ExtractFactsFromReader extracts facts from a reader (e.g., for testing)
+func (e *MemoryExtractor) ExtractFactsFromReader(reader io.Reader) ([]ExtractedFact, error) {
+	content, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read content: %w", err)
+	}
+
+	return parseExtractedFacts(string(content))
+}

--- a/src/semantic-router/pkg/memory/extractor_test.go
+++ b/src/semantic-router/pkg/memory/extractor_test.go
@@ -1,0 +1,557 @@
+package memory
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+// =============================================================================
+// ExtractFacts Tests
+// =============================================================================
+
+func TestExtractFacts_DisabledConfig(t *testing.T) {
+	// Test with nil config
+	extractor := NewMemoryExtractor(nil)
+	facts, err := extractor.ExtractFacts(context.Background(), []Message{
+		{Role: "user", Content: "My budget is $10,000"},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, facts, "should return nil when config is nil")
+
+	// Test with disabled config
+	extractor = NewMemoryExtractor(&config.ExtractionConfig{Enabled: false})
+	facts, err = extractor.ExtractFacts(context.Background(), []Message{
+		{Role: "user", Content: "My budget is $10,000"},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, facts, "should return nil when disabled")
+
+	// Test with empty endpoint
+	extractor = NewMemoryExtractor(&config.ExtractionConfig{Enabled: true, Endpoint: ""})
+	facts, err = extractor.ExtractFacts(context.Background(), []Message{
+		{Role: "user", Content: "My budget is $10,000"},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, facts, "should return nil when endpoint is empty")
+}
+
+func TestExtractFacts_EmptyMessages(t *testing.T) {
+	extractor := NewMemoryExtractor(&config.ExtractionConfig{
+		Enabled:  true,
+		Endpoint: "http://localhost:8080",
+	})
+
+	facts, err := extractor.ExtractFacts(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Nil(t, facts, "should return nil for nil messages")
+
+	facts, err = extractor.ExtractFacts(context.Background(), []Message{})
+	require.NoError(t, err)
+	assert.Nil(t, facts, "should return nil for empty messages")
+}
+
+func TestExtractFacts_SingleSemanticFact(t *testing.T) {
+	// Create mock LLM server
+	mockResponse := `[{"type": "semantic", "content": "User's budget for Hawaii vacation is $10,000"}]`
+	server := createMockLLMServer(t, mockResponse)
+	defer server.Close()
+
+	extractor := NewMemoryExtractor(&config.ExtractionConfig{
+		Enabled:  true,
+		Endpoint: server.URL,
+		Model:    "test-model",
+	})
+
+	messages := []Message{
+		{Role: "user", Content: "My budget for the Hawaii trip is $10,000"},
+		{Role: "assistant", Content: "That's a great budget for Hawaii!"},
+	}
+
+	facts, err := extractor.ExtractFacts(context.Background(), messages)
+	require.NoError(t, err)
+	require.Len(t, facts, 1)
+	assert.Equal(t, MemoryTypeSemantic, facts[0].Type)
+	assert.Equal(t, "User's budget for Hawaii vacation is $10,000", facts[0].Content)
+}
+
+func TestExtractFacts_MultipleFacts(t *testing.T) {
+	mockResponse := `[
+		{"type": "semantic", "content": "User's budget for Hawaii vacation is $10,000"},
+		{"type": "semantic", "content": "User prefers direct flights over connections"},
+		{"type": "procedural", "content": "To book flights: check prices on Google Flights first"}
+	]`
+	server := createMockLLMServer(t, mockResponse)
+	defer server.Close()
+
+	extractor := NewMemoryExtractor(&config.ExtractionConfig{
+		Enabled:  true,
+		Endpoint: server.URL,
+		Model:    "test-model",
+	})
+
+	messages := []Message{
+		{Role: "user", Content: "My budget is $10,000. I prefer direct flights."},
+		{Role: "assistant", Content: "I recommend checking Google Flights first for prices."},
+	}
+
+	facts, err := extractor.ExtractFacts(context.Background(), messages)
+	require.NoError(t, err)
+	require.Len(t, facts, 3)
+
+	assert.Equal(t, MemoryTypeSemantic, facts[0].Type)
+	assert.Equal(t, MemoryTypeSemantic, facts[1].Type)
+	assert.Equal(t, MemoryTypeProcedural, facts[2].Type)
+}
+
+func TestExtractFacts_EmptyArray(t *testing.T) {
+	// LLM returns empty array when nothing to extract
+	server := createMockLLMServer(t, "[]")
+	defer server.Close()
+
+	extractor := NewMemoryExtractor(&config.ExtractionConfig{
+		Enabled:  true,
+		Endpoint: server.URL,
+		Model:    "test-model",
+	})
+
+	messages := []Message{
+		{Role: "user", Content: "Hello!"},
+		{Role: "assistant", Content: "Hi there! How can I help?"},
+	}
+
+	facts, err := extractor.ExtractFacts(context.Background(), messages)
+	require.NoError(t, err)
+	assert.Nil(t, facts, "should return nil for empty extraction")
+}
+
+func TestExtractFacts_MarkdownCodeBlock(t *testing.T) {
+	// LLM sometimes wraps JSON in markdown code blocks
+	mockResponse := "```json\n[{\"type\": \"semantic\", \"content\": \"User likes coffee\"}]\n```"
+	server := createMockLLMServer(t, mockResponse)
+	defer server.Close()
+
+	extractor := NewMemoryExtractor(&config.ExtractionConfig{
+		Enabled:  true,
+		Endpoint: server.URL,
+		Model:    "test-model",
+	})
+
+	messages := []Message{
+		{Role: "user", Content: "I love coffee"},
+	}
+
+	facts, err := extractor.ExtractFacts(context.Background(), messages)
+	require.NoError(t, err)
+	require.Len(t, facts, 1)
+	assert.Equal(t, "User likes coffee", facts[0].Content)
+}
+
+func TestExtractFacts_LLMError(t *testing.T) {
+	// Create server that returns error
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	extractor := NewMemoryExtractor(&config.ExtractionConfig{
+		Enabled:  true,
+		Endpoint: server.URL,
+		Model:    "test-model",
+	})
+
+	messages := []Message{
+		{Role: "user", Content: "My budget is $10,000"},
+	}
+
+	// Should return nil (graceful degradation), not error
+	facts, err := extractor.ExtractFacts(context.Background(), messages)
+	require.NoError(t, err, "should not return error on LLM failure")
+	assert.Nil(t, facts, "should return nil on LLM failure")
+}
+
+func TestExtractFacts_InvalidJSON(t *testing.T) {
+	// LLM returns invalid JSON
+	server := createMockLLMServer(t, "not valid json at all")
+	defer server.Close()
+
+	extractor := NewMemoryExtractor(&config.ExtractionConfig{
+		Enabled:  true,
+		Endpoint: server.URL,
+		Model:    "test-model",
+	})
+
+	messages := []Message{
+		{Role: "user", Content: "My budget is $10,000"},
+	}
+
+	// Should return nil (graceful degradation)
+	facts, err := extractor.ExtractFacts(context.Background(), messages)
+	require.NoError(t, err, "should not return error on parse failure")
+	assert.Nil(t, facts, "should return nil on parse failure")
+}
+
+func TestExtractFacts_InvalidType(t *testing.T) {
+	// LLM returns invalid memory type - should be filtered
+	mockResponse := `[
+		{"type": "semantic", "content": "Valid fact"},
+		{"type": "invalid_type", "content": "Should be skipped"},
+		{"type": "procedural", "content": "Another valid fact"}
+	]`
+	server := createMockLLMServer(t, mockResponse)
+	defer server.Close()
+
+	extractor := NewMemoryExtractor(&config.ExtractionConfig{
+		Enabled:  true,
+		Endpoint: server.URL,
+		Model:    "test-model",
+	})
+
+	messages := []Message{
+		{Role: "user", Content: "Test message"},
+	}
+
+	facts, err := extractor.ExtractFacts(context.Background(), messages)
+	require.NoError(t, err)
+	require.Len(t, facts, 2, "should filter out invalid type")
+
+	assert.Equal(t, "Valid fact", facts[0].Content)
+	assert.Equal(t, "Another valid fact", facts[1].Content)
+}
+
+func TestExtractFacts_EmptyContent(t *testing.T) {
+	// Facts with empty content should be filtered
+	mockResponse := `[
+		{"type": "semantic", "content": "Valid fact"},
+		{"type": "semantic", "content": ""},
+		{"type": "semantic", "content": "   "}
+	]`
+	server := createMockLLMServer(t, mockResponse)
+	defer server.Close()
+
+	extractor := NewMemoryExtractor(&config.ExtractionConfig{
+		Enabled:  true,
+		Endpoint: server.URL,
+		Model:    "test-model",
+	})
+
+	messages := []Message{
+		{Role: "user", Content: "Test message"},
+	}
+
+	facts, err := extractor.ExtractFacts(context.Background(), messages)
+	require.NoError(t, err)
+	require.Len(t, facts, 1, "should filter out empty content")
+	assert.Equal(t, "Valid fact", facts[0].Content)
+}
+
+func TestExtractFacts_AllMemoryTypes(t *testing.T) {
+	mockResponse := `[
+		{"type": "semantic", "content": "User prefers window seats"},
+		{"type": "procedural", "content": "To reset password: go to settings, click security"},
+		{"type": "episodic", "content": "On Jan 5 2026, user booked flight to Hawaii"}
+	]`
+	server := createMockLLMServer(t, mockResponse)
+	defer server.Close()
+
+	extractor := NewMemoryExtractor(&config.ExtractionConfig{
+		Enabled:  true,
+		Endpoint: server.URL,
+		Model:    "test-model",
+	})
+
+	messages := []Message{
+		{Role: "user", Content: "Various conversation"},
+	}
+
+	facts, err := extractor.ExtractFacts(context.Background(), messages)
+	require.NoError(t, err)
+	require.Len(t, facts, 3)
+
+	assert.Equal(t, MemoryTypeSemantic, facts[0].Type)
+	assert.Equal(t, MemoryTypeProcedural, facts[1].Type)
+	assert.Equal(t, MemoryTypeEpisodic, facts[2].Type)
+}
+
+// =============================================================================
+// parseExtractedFacts Tests
+// =============================================================================
+
+func TestParseExtractedFacts_ValidJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected int
+	}{
+		{
+			name:     "single fact",
+			input:    `[{"type": "semantic", "content": "Budget is $10K"}]`,
+			expected: 1,
+		},
+		{
+			name:     "multiple facts",
+			input:    `[{"type": "semantic", "content": "A"}, {"type": "procedural", "content": "B"}]`,
+			expected: 2,
+		},
+		{
+			name:     "empty array",
+			input:    `[]`,
+			expected: 0,
+		},
+		{
+			name:     "with whitespace",
+			input:    `  [{"type": "semantic", "content": "Fact"}]  `,
+			expected: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			facts, err := parseExtractedFacts(tt.input)
+			require.NoError(t, err)
+			assert.Len(t, facts, tt.expected)
+		})
+	}
+}
+
+func TestParseExtractedFacts_MarkdownCleanup(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "json code block",
+			input: "```json\n[{\"type\": \"semantic\", \"content\": \"Fact\"}]\n```",
+		},
+		{
+			name:  "plain code block",
+			input: "```\n[{\"type\": \"semantic\", \"content\": \"Fact\"}]\n```",
+		},
+		{
+			name:  "code block with extra whitespace",
+			input: "```json\n  [{\"type\": \"semantic\", \"content\": \"Fact\"}]  \n```",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			facts, err := parseExtractedFacts(tt.input)
+			require.NoError(t, err)
+			require.Len(t, facts, 1)
+			assert.Equal(t, "Fact", facts[0].Content)
+		})
+	}
+}
+
+func TestParseExtractedFacts_InvalidJSON(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "not json",
+			input: "this is not json",
+		},
+		{
+			name:  "incomplete json",
+			input: `[{"type": "semantic"`,
+		},
+		{
+			name:  "wrong structure",
+			input: `{"type": "semantic", "content": "fact"}`, // not an array
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			facts, err := parseExtractedFacts(tt.input)
+			assert.Error(t, err, "should return error for: %s", tt.name)
+			assert.Nil(t, facts)
+		})
+	}
+}
+
+// =============================================================================
+// normalizeMemoryType Tests
+// =============================================================================
+
+func TestNormalizeMemoryType(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected MemoryType
+	}{
+		{"semantic", MemoryTypeSemantic},
+		{"SEMANTIC", MemoryTypeSemantic},
+		{"Semantic", MemoryTypeSemantic},
+		{"  semantic  ", MemoryTypeSemantic},
+		{"procedural", MemoryTypeProcedural},
+		{"PROCEDURAL", MemoryTypeProcedural},
+		{"episodic", MemoryTypeEpisodic},
+		{"EPISODIC", MemoryTypeEpisodic},
+		{"invalid", ""},
+		{"", ""},
+		{"unknown_type", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := normalizeMemoryType(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// =============================================================================
+// cleanJSONResponse Tests
+// =============================================================================
+
+func TestCleanJSONResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "plain json",
+			input:    `[{"type": "semantic"}]`,
+			expected: `[{"type": "semantic"}]`,
+		},
+		{
+			name:     "json code block",
+			input:    "```json\n[{\"type\": \"semantic\"}]\n```",
+			expected: `[{"type": "semantic"}]`,
+		},
+		{
+			name:     "plain code block",
+			input:    "```\n[{\"type\": \"semantic\"}]\n```",
+			expected: `[{"type": "semantic"}]`,
+		},
+		{
+			name:     "with surrounding whitespace",
+			input:    "  \n[{\"type\": \"semantic\"}]\n  ",
+			expected: `[{"type": "semantic"}]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := cleanJSONResponse(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// =============================================================================
+// formatMessagesForExtraction Tests
+// =============================================================================
+
+func TestFormatMessagesForExtraction(t *testing.T) {
+	messages := []Message{
+		{Role: "user", Content: "Hello"},
+		{Role: "assistant", Content: "Hi there!"},
+		{Role: "user", Content: "My budget is $10,000"},
+	}
+
+	result := formatMessagesForExtraction(messages)
+
+	assert.Contains(t, result, "[user]: Hello")
+	assert.Contains(t, result, "[assistant]: Hi there!")
+	assert.Contains(t, result, "[user]: My budget is $10,000")
+}
+
+func TestFormatMessagesForExtraction_Empty(t *testing.T) {
+	result := formatMessagesForExtraction(nil)
+	assert.Equal(t, "", result)
+
+	result = formatMessagesForExtraction([]Message{})
+	assert.Equal(t, "", result)
+}
+
+// =============================================================================
+// truncateForLog Tests
+// =============================================================================
+
+func TestTruncateForLog(t *testing.T) {
+	tests := []struct {
+		input    string
+		maxLen   int
+		expected string
+	}{
+		{"short", 10, "short"},
+		{"exactly10!", 10, "exactly10!"},
+		{"this is longer than ten", 10, "this is lo..."},
+		{"", 10, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := truncateForLog(tt.input, tt.maxLen)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// =============================================================================
+// Config Default Tests
+// =============================================================================
+
+func TestGetTimeoutForExtraction(t *testing.T) {
+	// Default timeout (nil config)
+	assert.Equal(t, int64(30000000000), getTimeoutForExtraction(&config.ExtractionConfig{}).Nanoseconds())
+
+	// Custom timeout
+	cfg := &config.ExtractionConfig{TimeoutSeconds: 60}
+	assert.Equal(t, int64(60000000000), getTimeoutForExtraction(cfg).Nanoseconds())
+}
+
+func TestGetMaxTokensForExtraction(t *testing.T) {
+	// Default
+	assert.Equal(t, 500, getMaxTokensForExtraction(&config.ExtractionConfig{}))
+
+	// Custom
+	cfg := &config.ExtractionConfig{MaxTokens: 1000}
+	assert.Equal(t, 1000, getMaxTokensForExtraction(cfg))
+}
+
+func TestGetTemperatureForExtraction(t *testing.T) {
+	// Default
+	assert.Equal(t, 0.1, getTemperatureForExtraction(&config.ExtractionConfig{}))
+
+	// Custom
+	cfg := &config.ExtractionConfig{Temperature: 0.5}
+	assert.Equal(t, 0.5, getTemperatureForExtraction(cfg))
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+// createMockLLMServer creates a test server that returns the specified response
+func createMockLLMServer(t *testing.T, factsJSON string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/v1/chat/completions", r.URL.Path)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		// Return mock response
+		response := map[string]interface{}{
+			"choices": []map[string]interface{}{
+				{
+					"message": map[string]string{
+						"content": factsJSON,
+					},
+				},
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+}

--- a/src/semantic-router/pkg/memory/types.go
+++ b/src/semantic-router/pkg/memory/types.go
@@ -2,22 +2,39 @@ package memory
 
 import "time"
 
-// MemoryType represents the category of a memory
+// MemoryType represents the category of a memory in the agentic memory system.
 type MemoryType string
 
 const (
-	// MemoryTypeSemantic represents facts, preferences, knowledge
+	// MemoryTypeSemantic represents facts, preferences, knowledge.
 	// Example: "User's budget for Hawaii is $10,000"
 	MemoryTypeSemantic MemoryType = "semantic"
 
-	// MemoryTypeProcedural represents instructions, how-to, steps
+	// MemoryTypeProcedural represents instructions, how-to, steps.
 	// Example: "To deploy payment-service: run npm build, then docker push"
 	MemoryTypeProcedural MemoryType = "procedural"
 
-	// MemoryTypeEpisodic represents session summaries, past events
+	// MemoryTypeEpisodic represents session summaries, past events.
 	// Example: "On Dec 29 2024, user planned Hawaii vacation with $10K budget"
 	MemoryTypeEpisodic MemoryType = "episodic"
 )
+
+// ExtractedFact represents a fact extracted by the LLM from conversation.
+// This is the output of ExtractFacts().
+type ExtractedFact struct {
+	// Type is the category (semantic, procedural, episodic)
+	Type MemoryType `json:"type"`
+
+	// Content is the extracted fact with context.
+	// Should be self-contained: "budget for Hawaii is $10K" not just "$10K"
+	Content string `json:"content"`
+}
+
+// Message represents a conversation message used for fact extraction.
+type Message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
 
 // Memory represents a stored memory unit in the agentic memory system
 type Memory struct {


### PR DESCRIPTION

Implement MemoryExtractor component that uses an LLM to extract
important facts from conversation history for long-term storage.
This is the fact extraction phase of the agentic memory pipeline.

Changes:
- Add extractor.go with MemoryExtractor component:
  * ExtractFacts() calls LLM to identify memorable information
  * Classifies facts as semantic (preferences) or procedural (how-to)
  * Enforces self-contained extraction (includes context, not bare values)
  * Handles markdown cleanup from LLM responses
  * Graceful degradation on errors (logs warning, returns empty)
  * Debug logging for POC demo visualization

- Add extractor_test.go with 22 unit tests covering:
  * Disabled/empty configuration handling
  * Single and multiple fact extraction
  * All memory types (semantic, procedural, episodic)
  * Markdown code block cleanup
  * LLM error handling and graceful fallback
  * JSON parsing and validation
  * Helper function edge cases

- Add ExtractedFact and Message types to types.go

- Add ExtractionConfig to config.go with:
  * LLM endpoint, model, max_tokens, temperature
  * Timeout and batch_size settings
  * Enabled flag for feature toggle

The extractor uses a carefully crafted system prompt that enforces
context inclusion (e.g., "User's budget for Hawaii is $10K" not
just "$10K") to ensure memories are meaningful when retrieved later.

Resolve #8 