### PR TITLE
feat(memory): implement deduplication logic

### DIFF
--- a/src/semantic-router/pkg/memory/deduplication.go
+++ b/src/semantic-router/pkg/memory/deduplication.go
@@ -1,0 +1,146 @@
+package memory
+
+import (
+	"context"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+)
+
+// DeduplicationConfig contains configuration for deduplication behavior
+type DeduplicationConfig struct {
+	// UpdateThreshold is the similarity threshold above which we UPDATE existing memory
+	// Default: 0.9
+	UpdateThreshold float32
+
+	// SearchThreshold is the minimum similarity to consider when searching for similar memories
+	// Default: 0.7
+	SearchThreshold float32
+}
+
+// DefaultDeduplicationConfig returns default deduplication configuration
+func DefaultDeduplicationConfig() DeduplicationConfig {
+	return DeduplicationConfig{
+		UpdateThreshold: 0.9,
+		SearchThreshold: 0.7,
+	}
+}
+
+// DeduplicationResult represents the result of deduplication check
+type DeduplicationResult struct {
+	// Action indicates what should be done: "update", "create", or "skip"
+	Action string
+
+	// ExistingMemory is the existing memory if similarity > UpdateThreshold
+	ExistingMemory *Memory
+
+	// Similarity is the similarity score (0.0 to 1.0)
+	Similarity float32
+}
+
+// FindSimilar searches for existing similar memories.
+// It searches for memories with the same user and type, and returns the most similar one.
+//
+// Parameters:
+//   - ctx: context
+//   - store: memory store to search in
+//   - userID: user ID to filter by
+//   - content: content to search for similarity
+//   - memType: memory type to filter by
+//   - config: deduplication configuration
+//
+// Returns:
+//   - *Memory: the most similar existing memory (nil if none found)
+//   - float32: similarity score (0.0 if none found)
+func FindSimilar(
+	ctx context.Context,
+	store Store,
+	userID string,
+	content string,
+	memType MemoryType,
+	config DeduplicationConfig,
+) (*Memory, float32) {
+	if store == nil || !store.IsEnabled() {
+		return nil, 0
+	}
+
+	// Search for similar memories using Retrieve
+	results, err := store.Retrieve(ctx, RetrieveOptions{
+		Query:     content,
+		UserID:    userID,
+		Types:     []MemoryType{memType},
+		Limit:     1, // Only need the most similar one
+		Threshold: config.SearchThreshold,
+	})
+
+	if err != nil {
+		logging.Debugf("Memory deduplication: search failed: %v", err)
+		return nil, 0
+	}
+
+	if len(results) == 0 {
+		logging.Debugf("Memory deduplication: no similar memories found for user=%s, type=%s", userID, memType)
+		return nil, 0
+	}
+
+	// Return the most similar memory (first result, already sorted by similarity)
+	result := results[0]
+	logging.Debugf("Memory deduplication: found similar memory id=%s, similarity=%.3f", result.Memory.ID, result.Score)
+	return result.Memory, result.Score
+}
+
+// CheckDeduplication checks if a new memory should be created, updated, or skipped.
+//
+// Logic:
+//   - If similarity > UpdateThreshold (default 0.9): UPDATE existing memory
+//   - If similarity 0.7-0.9: CREATE new (gray zone, conservative approach)
+//   - If similarity < 0.7: CREATE new
+//
+// Parameters:
+//   - ctx: context
+//   - store: memory store to search in
+//   - userID: user ID
+//   - content: new memory content
+//   - memType: memory type
+//   - config: deduplication configuration
+//
+// Returns:
+//   - DeduplicationResult with action, existing memory (if found), and similarity score
+func CheckDeduplication(
+	ctx context.Context,
+	store Store,
+	userID string,
+	content string,
+	memType MemoryType,
+	config DeduplicationConfig,
+) DeduplicationResult {
+	existing, similarity := FindSimilar(ctx, store, userID, content, memType, config)
+
+	if existing == nil || similarity < config.SearchThreshold {
+		// No similar memory found or below search threshold
+		return DeduplicationResult{
+			Action:         "create",
+			ExistingMemory: nil,
+			Similarity:     0,
+		}
+	}
+
+	if similarity > config.UpdateThreshold {
+		// Very similar → UPDATE existing memory
+		logging.Debugf("Memory deduplication: UPDATE existing memory id=%s (similarity=%.3f > %.3f)",
+			existing.ID, similarity, config.UpdateThreshold)
+		return DeduplicationResult{
+			Action:         "update",
+			ExistingMemory: existing,
+			Similarity:     similarity,
+		}
+	}
+
+	// Similarity in gray zone (0.7-0.9): CREATE new (conservative approach)
+	logging.Debugf("Memory deduplication: CREATE new memory (similarity=%.3f in gray zone %.3f-%.3f)",
+		similarity, config.SearchThreshold, config.UpdateThreshold)
+	return DeduplicationResult{
+		Action:         "create",
+		ExistingMemory: existing,
+		Similarity:     similarity,
+	}
+}

--- a/src/semantic-router/pkg/memory/deduplication_test.go
+++ b/src/semantic-router/pkg/memory/deduplication_test.go
@@ -1,0 +1,203 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	candle_binding "github.com/vllm-project/semantic-router/candle-binding"
+)
+
+func init() {
+	// Initialize BERT model for embeddings (required for similarity calculation)
+	err := candle_binding.InitModel("sentence-transformers/all-MiniLM-L6-v2", true)
+	if err != nil {
+		// Skip tests if model initialization fails (model might not be available)
+		fmt.Printf("Warning: Failed to initialize BERT model for tests: %v\n", err)
+		fmt.Printf("Tests will be skipped. Make sure models are downloaded.\n")
+	}
+}
+
+func TestDeduplicationLogic(t *testing.T) {
+	// Create in-memory store
+	store := NewInMemoryStore()
+	ctx := context.Background()
+	config := DefaultDeduplicationConfig()
+
+	// Test cases with different similarity levels
+	testCases := []struct {
+		name     string
+		content1 string
+		content2 string
+		expected string // "update" or "create"
+	}{
+		{
+			name:     "Exact duplicate - Should UPDATE",
+			content1: "User's budget for Hawaii vacation is $10,000",
+			content2: "User's budget for Hawaii vacation is $10,000",
+			expected: "update",
+		},
+		{
+			name:     "Very similar wording - Should UPDATE",
+			content1: "My budget for the Hawaii trip is $10,000",
+			content2: "My budget for Hawaii vacation is $10,000",
+			expected: "update",
+		},
+		{
+			name:     "Similar with value change - Should UPDATE",
+			content1: "User's budget for Hawaii vacation is $10,000",
+			content2: "User's budget for Hawaii trip is now $15,000",
+			expected: "update",
+		},
+		{
+			name:     "Different topic - Should CREATE",
+			content1: "User's budget for Hawaii vacation is $10,000",
+			content2: "User likes chocolate ice cream",
+			expected: "create",
+		},
+		{
+			name:     "Related but different - Should CREATE (gray zone)",
+			content1: "User's budget for Hawaii vacation is $10,000",
+			content2: "User prefers direct flights to Hawaii",
+			expected: "create",
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("Test_%d_%s", i+1, tc.name), func(t *testing.T) {
+			// Store first memory
+			mem1 := &Memory{
+				ID:        fmt.Sprintf("mem_%d_1", i),
+				Type:      MemoryTypeSemantic,
+				Content:   tc.content1,
+				UserID:    "test_user",
+				CreatedAt: time.Now(),
+			}
+
+			if err := store.Store(ctx, mem1); err != nil {
+				t.Fatalf("Failed to store first memory: %v", err)
+			}
+
+			// Check deduplication for second content
+			result := CheckDeduplication(ctx, store, "test_user", tc.content2, MemoryTypeSemantic, config)
+
+			t.Logf("Content 1: %s", tc.content1)
+			t.Logf("Content 2: %s", tc.content2)
+			t.Logf("Similarity: %.4f", result.Similarity)
+			t.Logf("Action: %s (expected: %s)", result.Action, tc.expected)
+
+			if result.Action != tc.expected {
+				t.Errorf("Expected action %s, got %s (similarity=%.4f)", tc.expected, result.Action, result.Similarity)
+			}
+
+			if result.Action == "update" && result.ExistingMemory == nil {
+				t.Error("Update action but no existing memory found")
+			}
+		})
+	}
+}
+
+func TestDeduplicationMultipleMemories(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+	config := DefaultDeduplicationConfig()
+
+	// Store multiple memories for same user
+	memories := []string{
+		"User's budget for Hawaii vacation is $10,000",
+		"User prefers direct flights",
+		"User likes beach hotels",
+	}
+
+	for i, content := range memories {
+		mem := &Memory{
+			ID:        fmt.Sprintf("multi_mem_%d", i),
+			Type:      MemoryTypeSemantic,
+			Content:   content,
+			UserID:    "test_user_2",
+			CreatedAt: time.Now(),
+		}
+		if err := store.Store(ctx, mem); err != nil {
+			t.Fatalf("Failed to store memory: %v", err)
+		}
+	}
+
+	// Test deduplication with similar content
+	testContent := "User's budget for Hawaii trip is $10,000"
+	result := CheckDeduplication(ctx, store, "test_user_2", testContent, MemoryTypeSemantic, config)
+
+	t.Logf("Testing: %s", testContent)
+	t.Logf("Similarity: %.4f", result.Similarity)
+	t.Logf("Action: %s", result.Action)
+	if result.ExistingMemory != nil {
+		t.Logf("Matched with: %s", result.ExistingMemory.Content)
+	}
+
+	// Should find the first memory (budget) and update it
+	if result.Action != "update" {
+		t.Errorf("Expected update action, got %s", result.Action)
+	}
+	if result.ExistingMemory == nil {
+		t.Error("Expected to find existing memory")
+	}
+	if result.ExistingMemory.Content != memories[0] {
+		t.Errorf("Expected to match first memory, got: %s", result.ExistingMemory.Content)
+	}
+}
+
+func TestDeduplicationUserIsolation(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+	config := DefaultDeduplicationConfig()
+
+	// Store memory for user1
+	mem1 := &Memory{
+		ID:        "user1_mem",
+		Type:      MemoryTypeSemantic,
+		Content:   "User's budget for Hawaii vacation is $10,000",
+		UserID:    "user1",
+		CreatedAt: time.Now(),
+	}
+	if err := store.Store(ctx, mem1); err != nil {
+		t.Fatalf("Failed to store memory: %v", err)
+	}
+
+	// Try to find similar for user2 (should not find)
+	result := CheckDeduplication(ctx, store, "user2", "User's budget for Hawaii vacation is $10,000", MemoryTypeSemantic, config)
+
+	if result.Action != "create" {
+		t.Errorf("Expected create action (user isolation), got %s", result.Action)
+	}
+	if result.ExistingMemory != nil {
+		t.Error("Should not find memory from different user")
+	}
+}
+
+func TestDeduplicationTypeIsolation(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+	config := DefaultDeduplicationConfig()
+
+	// Store semantic memory
+	mem1 := &Memory{
+		ID:        "semantic_mem",
+		Type:      MemoryTypeSemantic,
+		Content:   "User's budget for Hawaii vacation is $10,000",
+		UserID:    "test_user",
+		CreatedAt: time.Now(),
+	}
+	if err := store.Store(ctx, mem1); err != nil {
+		t.Fatalf("Failed to store memory: %v", err)
+	}
+
+	// Try to find similar for procedural type (should not find)
+	result := CheckDeduplication(ctx, store, "test_user", "User's budget for Hawaii vacation is $10,000", MemoryTypeProcedural, config)
+
+	if result.Action != "create" {
+		t.Errorf("Expected create action (type isolation), got %s", result.Action)
+	}
+	if result.ExistingMemory != nil {
+		t.Error("Should not find memory of different type")
+	}
+}

--- a/src/semantic-router/pkg/memory/inmemory_store.go
+++ b/src/semantic-router/pkg/memory/inmemory_store.go
@@ -1,0 +1,297 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sort"
+	"sync"
+	"time"
+
+	candle_binding "github.com/vllm-project/semantic-router/candle-binding"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+)
+
+// InMemoryStore is an in-memory implementation of Store for testing and POC.
+// It stores memories in memory with embedding-based similarity search.
+type InMemoryStore struct {
+	mu       sync.RWMutex
+	memories map[string]*Memory // ID -> Memory
+	enabled  bool
+}
+
+// NewInMemoryStore creates a new in-memory memory store.
+func NewInMemoryStore() *InMemoryStore {
+	return &InMemoryStore{
+		memories: make(map[string]*Memory),
+		enabled:  true,
+	}
+}
+
+// IsEnabled returns whether the store is enabled.
+func (s *InMemoryStore) IsEnabled() bool {
+	return s.enabled
+}
+
+// Store saves a new memory.
+func (s *InMemoryStore) Store(ctx context.Context, memory *Memory) error {
+	if !s.enabled {
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Generate embedding if not already set
+	if memory.Embedding == nil || len(memory.Embedding) == 0 {
+		embedding, err := candle_binding.GetEmbedding(memory.Content, 0)
+		if err != nil {
+			return err
+		}
+		memory.Embedding = embedding
+	}
+
+	// Check if ID already exists
+	if _, exists := s.memories[memory.ID]; exists {
+		return fmt.Errorf("memory with ID %s already exists", memory.ID)
+	}
+
+	// Set CreatedAt if not set
+	if memory.CreatedAt.IsZero() {
+		memory.CreatedAt = time.Now()
+	}
+
+	s.memories[memory.ID] = memory
+	logging.Debugf("InMemoryStore: stored memory id=%s, type=%s, user=%s", memory.ID, memory.Type, memory.UserID)
+	return nil
+}
+
+// Retrieve performs semantic search for relevant memories.
+func (s *InMemoryStore) Retrieve(ctx context.Context, opts RetrieveOptions) ([]*RetrieveResult, error) {
+	if !s.enabled {
+		return nil, nil
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	// Generate embedding for query
+	queryEmbedding, err := candle_binding.GetEmbedding(opts.Query, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []*RetrieveResult
+
+	// Search through all memories
+	for _, mem := range s.memories {
+		// Filter by user ID
+		if opts.UserID != "" && mem.UserID != opts.UserID {
+			continue
+		}
+
+		// Filter by project ID if specified
+		if opts.ProjectID != "" && mem.ProjectID != opts.ProjectID {
+			continue
+		}
+
+		// Filter by types if specified
+		if len(opts.Types) > 0 {
+			found := false
+			for _, t := range opts.Types {
+				if mem.Type == t {
+					found = true
+					break
+				}
+			}
+			if !found {
+				continue
+			}
+		}
+
+		// Calculate similarity
+		similarity := cosineSimilarity(queryEmbedding, mem.Embedding)
+		if similarity < opts.Threshold {
+			continue
+		}
+
+		results = append(results, &RetrieveResult{
+			Memory: mem,
+			Score:  similarity,
+		})
+	}
+
+	// Sort by similarity (descending)
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Score > results[j].Score
+	})
+
+	// Apply limit
+	if opts.Limit > 0 && len(results) > opts.Limit {
+		results = results[:opts.Limit]
+	}
+
+	return results, nil
+}
+
+// Get retrieves a memory by ID.
+func (s *InMemoryStore) Get(ctx context.Context, id string) (*Memory, error) {
+	if !s.enabled {
+		return nil, fmt.Errorf("store not enabled")
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	mem, exists := s.memories[id]
+	if !exists {
+		return nil, fmt.Errorf("memory not found: %s", id)
+	}
+
+	return mem, nil
+}
+
+// Update modifies an existing memory.
+func (s *InMemoryStore) Update(ctx context.Context, id string, memory *Memory) error {
+	if !s.enabled {
+		return fmt.Errorf("store not enabled")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Check if memory exists
+	existing, exists := s.memories[id]
+	if !exists {
+		return fmt.Errorf("memory not found: %s", id)
+	}
+
+	// Update fields
+	existing.Content = memory.Content
+	existing.Type = memory.Type
+	existing.UpdatedAt = time.Now()
+	if memory.ProjectID != "" {
+		existing.ProjectID = memory.ProjectID
+	}
+	if memory.Source != "" {
+		existing.Source = memory.Source
+	}
+
+	// Regenerate embedding if content changed
+	if existing.Content != memory.Content {
+		embedding, err := candle_binding.GetEmbedding(memory.Content, 0)
+		if err != nil {
+			return err
+		}
+		existing.Embedding = embedding
+	}
+
+	logging.Debugf("InMemoryStore: updated memory id=%s", id)
+	return nil
+}
+
+// Forget deletes a memory by ID.
+func (s *InMemoryStore) Forget(ctx context.Context, id string) error {
+	if !s.enabled {
+		return fmt.Errorf("store not enabled")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.memories[id]; !exists {
+		return fmt.Errorf("memory not found: %s", id)
+	}
+
+	delete(s.memories, id)
+	logging.Debugf("InMemoryStore: deleted memory id=%s", id)
+	return nil
+}
+
+// ForgetByScope deletes all memories matching the scope.
+func (s *InMemoryStore) ForgetByScope(ctx context.Context, scope MemoryScope) error {
+	if !s.enabled {
+		return fmt.Errorf("store not enabled")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var toDelete []string
+	for id, mem := range s.memories {
+		// Must match user ID
+		if mem.UserID != scope.UserID {
+			continue
+		}
+
+		// Optionally match project ID
+		if scope.ProjectID != "" && mem.ProjectID != scope.ProjectID {
+			continue
+		}
+
+		// Optionally match types
+		if len(scope.Types) > 0 {
+			found := false
+			for _, t := range scope.Types {
+				if mem.Type == t {
+					found = true
+					break
+				}
+			}
+			if !found {
+				continue
+			}
+		}
+
+		toDelete = append(toDelete, id)
+	}
+
+	for _, id := range toDelete {
+		delete(s.memories, id)
+	}
+
+	logging.Debugf("InMemoryStore: deleted %d memories by scope", len(toDelete))
+	return nil
+}
+
+// CheckConnection verifies the store connection is healthy.
+// For in-memory store, this is always healthy (no external connection).
+func (s *InMemoryStore) CheckConnection(ctx context.Context) error {
+	if !s.enabled {
+		return fmt.Errorf("store not enabled")
+	}
+	// In-memory store has no external connection to check
+	return nil
+}
+
+// Close releases resources.
+func (s *InMemoryStore) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.memories = nil
+	s.enabled = false
+	return nil
+}
+
+// cosineSimilarity calculates cosine similarity between two vectors
+func cosineSimilarity(a, b []float32) float32 {
+	if len(a) != len(b) {
+		return 0
+	}
+
+	var dotProduct float32
+	var normA, normB float32
+
+	for i := range a {
+		dotProduct += a[i] * b[i]
+		normA += a[i] * a[i]
+		normB += b[i] * b[i]
+	}
+
+	if normA == 0 || normB == 0 {
+		return 0
+	}
+
+	return dotProduct / (float32(math.Sqrt(float64(normA))) * float32(math.Sqrt(float64(normB))))
+}

--- a/src/semantic-router/pkg/memory/store.go
+++ b/src/semantic-router/pkg/memory/store.go
@@ -1,0 +1,42 @@
+package memory
+
+import (
+	"context"
+)
+
+// Store defines the interface for storing and retrieving memories.
+// Implementations must be thread-safe.
+type Store interface {
+	// Store saves a new memory.
+	// Returns error if the memory ID already exists.
+	Store(ctx context.Context, memory *Memory) error
+
+	// Retrieve performs semantic search for relevant memories.
+	// Uses embedding-based similarity search.
+	Retrieve(ctx context.Context, opts RetrieveOptions) ([]*RetrieveResult, error)
+
+	// Get retrieves a memory by ID.
+	// Returns nil and error if the memory doesn't exist.
+	Get(ctx context.Context, id string) (*Memory, error)
+
+	// Update modifies an existing memory.
+	// Returns error if the memory doesn't exist.
+	Update(ctx context.Context, id string, memory *Memory) error
+
+	// Forget deletes a memory by ID.
+	// Returns error if the memory doesn't exist.
+	Forget(ctx context.Context, id string) error
+
+	// ForgetByScope deletes all memories matching the scope.
+	// Scope includes UserID (required), ProjectID (optional), Types (optional).
+	ForgetByScope(ctx context.Context, scope MemoryScope) error
+
+	// IsEnabled returns whether the store is enabled.
+	IsEnabled() bool
+
+	// CheckConnection verifies the store connection is healthy.
+	CheckConnection(ctx context.Context) error
+
+	// Close releases resources held by the store.
+	Close() error
+}


### PR DESCRIPTION
Implement memory deduplication system to prevent duplicate memories by using semantic similarity comparison. The system decides when to update existing memories vs creating new ones based on configurable thresholds.

Changes:
- Add deduplication.go with FindSimilar() and CheckDeduplication() functions
- Add store.go interface for memory storage abstraction
- Add inmemory_store.go implementation with embedding-based similarity search
- Update extractor.go to integrate deduplication in ProcessResponse() method
- Add comprehensive test suite in deduplication_test.go
- Remove debug logs and TODO comments

Deduplication logic:
- UpdateThreshold: 0.9 (similarity > 0.9 → UPDATE)
- SearchThreshold: 0.7 (minimum similarity to consider)
- Gray zone (0.7-0.9): CREATE new (conservative approach)

The implementation uses cosine similarity on embeddings generated by the BERT model (all-MiniLM-L6-v2) to compare new memories with existing ones. User and type isolation ensures memories are only compared within the same context.

Resolves #9 