### PR TITLE
feat(memory): implement MilvusStore write operations

### DIFF
--- a/src/semantic-router/pkg/extproc/req_filter_memory.go
+++ b/src/semantic-router/pkg/extproc/req_filter_memory.go
@@ -27,8 +27,6 @@ import (
 // - Are general fact questions (answered by LLM's knowledge)
 // - Require tools (tool provides the answer)
 // - Are simple greetings (no context needed)
-//
-// See: https://github.com/yehudit1987/semantic-router/issues/2
 
 // personalPronounPattern matches personal pronouns that indicate user-specific context
 // These override the fact-check signal for personal questions like "What is my budget?"
@@ -397,8 +395,6 @@ func ExtractConversationHistory(messagesJSON []byte) ([]ConversationMessage, err
 // Graceful handling:
 //   - If no memories found → returns original request unchanged
 //   - If injection fails → logs warning and returns original request
-//
-// See: https://github.com/yehudit1987/semantic-router/issues/5
 func InjectMemories(requestBody []byte, memories []*memory.RetrieveResult) ([]byte, error) {
 	// No memories to inject
 	if len(memories) == 0 {


### PR DESCRIPTION
Complete the Store interface implementation for MilvusStore by adding
all missing write operations required for agentic memory persistence.

Changes:
- Add Store() method for saving new memories with auto-embedding
- Add Get() method for retrieving memory by ID
- Add Update() method using delete+insert pattern (Milvus limitation)
- Add Forget() method for single memory deletion
- Add ForgetByScope() method for bulk deletion by user/project/type
- Fix Retrieve() return type to []*RetrieveResult for interface compliance
- Add 13 unit tests covering success paths and edge cases
- Extend MockMilvusClient with Insert, Delete, Query function mocks
- Add documentation comments for POC trade-offs:
  * Non-atomic Update operation
  * Embedding dimension validation (warn-only)
  * One-by-one deletion in ForgetByScope

Minor cleanup:
- Apply go fmt formatting fixes

Resolves #7